### PR TITLE
use fetch() and co/yield for http requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,11 @@
     "eslint": "^2.13.1",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.11.1",
+    "exports-loader": "^0.6.3",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "html-loader": "^0.4.3",
+    "imports-loader": "^0.6.5",
     "live-server": "^1.0.0",
     "nightwatch": "^0.9.5",
     "node-sass": "^3.8.0",
@@ -52,7 +54,10 @@
   },
   "dependencies": {
     "babel-runtime": "^6.9.2",
+    "co": "^4.6.0",
+    "es6-promise": "^3.2.1",
     "lodash": "^4.13.1",
-    "query-string": "^4.2.2"
+    "query-string": "^4.2.2",
+    "whatwg-fetch": "^1.0.0"
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="utf-8"/>
-    <script src="index.js"></script>
     <title>PaperHive widget</title>
   </head>
   <body>
+    <script src="index.js"></script>
   </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -1,77 +1,61 @@
+import co from 'co';
 import queryString from 'query-string';
 
 import './index.html';
 import './index.scss';
-import { httpGetJSON, shortenNumber } from './utils.js';
+import { response2json, shortenNumber } from './utils.js';
 import logo from '../static/img/logo-hexagon.svg';
 import template from './index.ejs';
 
 const apiUrl = 'https://paperhive.org/api';
 
-function updateHtml(data) {
-  document.body.innerHTML = template(data);
-}
-
-function getData() {
+const getData = co.wrap(function* getData() {
   const query = queryString.parse(window.location.hash);
 
   const remoteUrl = `${apiUrl}/documents/remote?${
     queryString.stringify({ type: query.type, id: query.id })
   }`;
-  httpGetJSON(remoteUrl, (documentErr, documentResponse) => {
-    if (documentErr) {
-      // eslint-disable-next-line no-console
-      console.error(documentErr);
-      return;
-    }
-    if (documentResponse.status === 404) {
-      // eslint-disable-next-line no-console
-      console.log(`Document with type ${query.type} and id ${query.id} not found on PaperHive`);
-      return;
-    }
-    if (documentResponse.status !== 200) {
-      // eslint-disable-next-line no-console
-      console.error(`Expected status code 200 (got ${documentResponse.status})`);
-      return;
-    }
-    const discussionsUrl = `${apiUrl}/documents/${documentResponse.body.id}/discussions`;
-    httpGetJSON(discussionsUrl, (discussionsErr, discussionsResponse) => {
-      if (documentErr) {
-        // eslint-disable-next-line no-console
-        console.error(documentErr);
-        return;
-      }
-      if (documentResponse.status !== 200) {
-        // eslint-disable-next-line no-console
-        console.error(`Expected status code 200 (got ${documentResponse.status})`);
-        return;
-      }
-      const hiversUrl = `${apiUrl}/documents/${documentResponse.body.id}/hivers`;
-      httpGetJSON(hiversUrl, (hiversErr, hiversResponse) => {
-        if (documentErr) {
-          // eslint-disable-next-line no-console
-          console.error(documentErr);
-          return;
-        }
-        if (documentResponse.status !== 200) {
-          // eslint-disable-next-line no-console
-          console.error(`Expected status code 200 (got ${documentResponse.status})`);
-          return;
-        }
-        updateHtml({
-          logo,
-          numDiscussions: discussionsResponse.body.discussions.length,
-          numHives: hiversResponse.body.hivers.length,
-          shortenNumber,
-          url: `https://paperhive.org/documents/${documentResponse.body.id}`,
-        });
-      });
-    });
-  });
-}
+  const documentResponse = yield fetch(remoteUrl);
+  if (documentResponse.status === 404) {
+    throw new Error(`Document with type ${query.type} and id ${query.id} not found on PaperHive`);
+  }
+  const doc = yield response2json(documentResponse);
 
-window.addEventListener('hashchange', getData);
-getData();
+  // get discussions and hivers
+  const [discussionsResponse, hiversResponse] = yield [
+    fetch(`${apiUrl}/documents/${doc.id}/discussions`),
+    fetch(`${apiUrl}/documents/${doc.id}/hivers`),
+  ];
+  const [discussions, hivers] =
+    yield [response2json(discussionsResponse), response2json(hiversResponse)];
+
+  return {
+    doc,
+    discussions: discussions.discussions,
+    hivers: hivers.hivers,
+  };
+});
+
+const update = co.wrap(function* update() {
+  const target = window.document.body;
+  try {
+    const { doc, discussions, hivers } = yield getData();
+    target.innerHTML = template({
+      logo,
+      numDiscussions: discussions.length,
+      numHives: hivers.length,
+      shortenNumber,
+      url: `https://paperhive.org/documents/${doc.id}`,
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    target.innerHTML = '';
+  }
+});
+
+window.addEventListener('hashchange', update);
+update();
 
 
 // -----

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,29 +1,15 @@
+// take a fetch() response and turn it into JSON (if status is 200)
+export function response2json(response) {
+  if (response.status !== 200) {
+    throw new Error(`Expected status code 200 (got ${response.status})`);
+  }
+  return response.json();
+}
+
 // 10000 => 10K, 10000000 => 10M
 export function shortenNumber(number) {
   if (number < 1e3) return number;
   if (number < 1e6) return `${Math.floor(number / 1e3)}K`;
   if (number < 1e9) return `${Math.floor(number / 1e6)}M`;
   return '>999M';
-}
-
-// HTTP request -> GET number of discussions for and link to document
-// TODO replace with fetch (https://developer.mozilla.org/en/docs/Web/API/Fetch_API)
-export function httpGetJSON(url, callback) {
-  const request = new XMLHttpRequest();
-  request.onload = () => {
-    // receive response from PaperHive Server
-    let body;
-    try {
-      body = JSON.parse(request.responseText);
-    } catch (error) {
-      callback(new Error('could not parse JSON'));
-      return;
-    }
-    callback(undefined, { status: request.status, body });
-  };
-  request.onerror = () => {
-    callback(new Error('HTTP request failed (possibly a network error)'));
-  };
-  request.open('GET', url, true);
-  request.send(null);
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const ExtractText = require('extract-text-webpack-plugin');
+const webpack = require('webpack');
 
 const extractHtml = new ExtractText('index.html');
 
@@ -6,13 +7,13 @@ module.exports = {
   entry: './src/index.js',
   output: {
     path: './build',
-    filename: 'index.js'
+    filename: 'index.js',
   },
   module: {
     loaders: [
       {
         test: /\.ejs$/,
-        loader: 'ejs-loader'
+        loader: 'ejs-loader',
       },
       {
         test: /\.js$/,
@@ -21,7 +22,7 @@ module.exports = {
         query: {
           presets: ['es2015'],
           plugins: ['transform-runtime'],
-        }
+        },
       },
       {
         test: /\.html$/,
@@ -29,15 +30,19 @@ module.exports = {
       },
       {
         test: /\.scss$/,
-        loaders: ['style', 'css', 'sass']
+        loaders: ['style', 'css', 'sass'],
       },
       {
         test: /\.svg$/,
-        loaders: ['url', 'svgo-loader?' + JSON.stringify({plugins: []}) ],
+        loaders: ['url', `svgo-loader?${JSON.stringify({ plugins: [] })}`],
       },
-    ]
+    ],
   },
   plugins: [
     extractHtml,
-  ]
+    new webpack.ProvidePlugin({
+      Promise: 'imports?this=>global!exports?global.Promise!es6-promise',
+      fetch: 'imports?this=>global!exports?global.fetch!whatwg-fetch',
+    }),
+  ],
 };


### PR DESCRIPTION
Replace xmlhttprequest with fetch. The webpack config takes care of including the [shim](https://github.com/github/fetch) and its [Promise](https://github.com/stefanpenner/es6-promise) dependency.

Benefits:
 * cleaner code
 * parallel discussions+hivers requests